### PR TITLE
don't check '\\server\.local.vimrc'.

### DIFF
--- a/autoload/localrc.vim
+++ b/autoload/localrc.vim
@@ -31,7 +31,7 @@ function! localrc#search(fnames, ...)
     let targets = s:match_files(dir, a:fnames) + targets
     let updir = dir
     let dir = fnamemodify(dir, ':h')
-    if (has('win32') || has('win64')) && dir =~ '\\\\[^\\]\+$'
+    if (has('win32') || has('win64')) && dir =~ '^\\\\[^\\]\+$'
       break
     endif
     let depth -= 1


### PR DESCRIPTION
https://github.com/vim-jp/issues/issues/113

これの原因が分かりました。
どうやら localrc が UNC パスをさかのぼって `\\server\.local.vimrc` を探しに行ってた様です。で、`.local.vimrc` がシェアフォルダ名となって、探しに行ってしまった様です。
