### PR TITLE
Various Enhancements

### DIFF
--- a/after/ftplugin.vim
+++ b/after/ftplugin.vim
@@ -1,0 +1,43 @@
+" Enable configuration file of each directory.
+" Version: 0.1.3
+" Author : thinca <thinca+vim@gmail.com>
+" License: Creative Commons Attribution 2.1 Japan License
+"          <http://creativecommons.org/licenses/by/2.1/jp/deed.en>
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+" Execution order:
+" 1. global localrc configuration
+" 2. Vim ftplugins
+" 3. filetype-specific localrc configuration
+
+augroup filetypeplugin
+  " Undo the autocmd from ftplugin.vim.
+  au!
+
+  " Execute global localrc configuration before Vim ftplugins.
+  autocmd FileType * nested
+  \   if !exists('b:localrc_done') | call localrc#load(g:localrc_filename) | let b:localrc_done = 1 | endif
+augroup END
+
+" Restore the autocmd from ftplugin.vim; we have to invoke it because it
+" installs a script-local function s:LoadFTPlugin().
+" Note: We cannot load this via :filetype plugin on, because that one would
+" re-execute this after/ftplugin.vim script again, too, and lead to endless
+" recursion.
+unlet! did_load_ftplugin
+runtime ftplugin.vim
+
+" Handle filetype-specific localrc configuration after Vim ftplugins.
+augroup filetypeplugin
+  autocmd FileType * nested
+  \   call localrc#loadft(
+  \     type(g:localrc_filetype) == type([]) ? copy(g:localrc_filetype)
+  \                                          : [g:localrc_filetype],
+  \     expand("<amatch>"))
+augroup END
+
+
+let &cpo = s:save_cpo
+unlet s:save_cpo

--- a/after/ftplugin.vim
+++ b/after/ftplugin.vim
@@ -4,6 +4,10 @@
 " License: Creative Commons Attribution 2.1 Japan License
 "          <http://creativecommons.org/licenses/by/2.1/jp/deed.en>
 
+if v:version < 700
+  finish
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 

--- a/after/ftplugin.vim
+++ b/after/ftplugin.vim
@@ -11,6 +11,13 @@ endif
 let s:save_cpo = &cpo
 set cpo&vim
 
+function! s:has_localrc()
+  " The user may have disabled the plugin via :let g:loaded_localrc = 1.
+  " In this case, we must not invoke the localrc functions. The best way to
+  " check is to look for the autocmds installed by localrc.
+  return exists('#plugin-localrc#BufReadPost')
+endfunction
+
 " Execution order:
 " 1. global localrc configuration
 " 2. Vim ftplugins
@@ -22,7 +29,10 @@ augroup filetypeplugin
 
   " Execute global localrc configuration before Vim ftplugins.
   autocmd FileType * nested
-  \   if !exists('b:localrc_done') | call localrc#load(g:localrc_filename) | let b:localrc_done = 1 | endif
+  \   if s:has_localrc() && !exists('b:localrc_done') |
+  \     call localrc#load(g:localrc_filename) |
+  \     let b:localrc_done = 1 |
+  \   endif
 augroup END
 
 " Restore the autocmd from ftplugin.vim; we have to invoke it because it
@@ -36,10 +46,12 @@ runtime ftplugin.vim
 " Handle filetype-specific localrc configuration after Vim ftplugins.
 augroup filetypeplugin
   autocmd FileType * nested
-  \   call localrc#loadft(
-  \     type(g:localrc_filetype) == type([]) ? copy(g:localrc_filetype)
-  \                                          : [g:localrc_filetype],
-  \     expand("<amatch>"))
+  \   if s:has_localrc() |
+  \     call localrc#loadft(
+  \       type(g:localrc_filetype) == type([]) ? copy(g:localrc_filetype)
+  \                                            : [g:localrc_filetype],
+  \       expand("<amatch>")) |
+  \   endif
 augroup END
 
 

--- a/autoload/localrc.vim
+++ b/autoload/localrc.vim
@@ -38,7 +38,7 @@ function! localrc#load(fnames, ...)
   \                          2 <= a:0 ? a:2 : -1)
     try
       execute 'source' fnameescape(file)
-    catch /^Vim\%((\a\+)\)\=:E/
+    catch /^Vim\%((\a\+)\)\=:/
       " v:exception contains what is normally in v:errmsg, but with extra
       " exception source info prepended, which we cut away.
       let v:errmsg = substitute(v:exception, '^Vim\%((\a\+)\)\=:', '', '')

--- a/autoload/localrc.vim
+++ b/autoload/localrc.vim
@@ -6,6 +6,27 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
+function! localrc#loadft(templnames, ft)
+  " The 'filetype' setting can consist of multiple filetypes, separated by a
+  " dot, e.g. "foo.bar". Settings for subsequent filetypes override earlier
+  " ones, so execute filetype-specific localrc files in this order:
+  " foo, bar, foo.bar
+  let ftparts = split(a:ft, '\.')
+  for combination in range(1, len(ftparts) - 1)
+    call add(ftparts, join(ftparts[0:combination], '.'))
+  endfor
+
+  for ftpart in ftparts
+    " The ordering of filetypes has higher precendence than the configuration
+    " file's level in the file system hierarchy, so execute the loading (which
+    " executes all matches in each step in the hierarcy together) separately for
+    " each filetype part.
+    "
+    " Note: If fname is a regular expression, the filetype separator "." must be
+    " escaped.
+    call localrc#load(map(copy(a:templnames), 'printf(v:val, (v:val[0] == "/" ? escape(ftpart, ".") : ftpart))'))
+  endfor
+endfunction
 
 function! localrc#load(fnames, ...)
   for file in localrc#search(a:fnames,

--- a/autoload/localrc.vim
+++ b/autoload/localrc.vim
@@ -72,6 +72,11 @@ function! localrc#search(fnames, ...)
   return targets
 endfunction
 
+function! s:combine_path(path1, path2)
+    let sep = (exists('+shellslash') && ! &shellslash ? '\' : '/')
+    return a:path1 . sep . substitute(a:path2, '^[/\\]', '', '')
+endfunction
+
 function! s:match_files(path, fname)
   if type(a:fname) == type([])
     let files = []
@@ -83,8 +88,8 @@ function! s:match_files(path, fname)
 
   let path = escape(a:path, '*?[,')
   if a:fname[0] == '/'
-    let files = split(globpath(path, '/.*', 1), "\n")
-    \         + split(globpath(path, '/*' , 1), "\n")
+    let files = split(globpath(path, '.[^.]*', 1), "\n")
+    \         + split(globpath(path, '*' , 1), "\n")
     let pat = a:fname[1:]
     call filter(map(files, 'fnamemodify(v:val, ":t")'), 'v:val =~# pat')
 
@@ -93,7 +98,7 @@ function! s:match_files(path, fname)
     \               'fnamemodify(v:val, ":t")')
   endif
 
-  return filter(map(files, 'a:path . "/" . v:val'), 'filereadable(v:val)')
+  return filter(map(files, 's:combine_path(a:path, v:val)'), 'filereadable(v:val)')
 endfunction
 
 " - string only.

--- a/autoload/localrc.vim
+++ b/autoload/localrc.vim
@@ -7,6 +7,10 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! localrc#loadft(templnames, ft)
+  if empty(a:ft)
+    return
+  endif
+
   " The 'filetype' setting can consist of multiple filetypes, separated by a
   " dot, e.g. "foo.bar". Settings for subsequent filetypes override earlier
   " ones, so execute filetype-specific localrc files in this order:
@@ -32,8 +36,17 @@ function! localrc#load(fnames, ...)
   for file in localrc#search(a:fnames,
   \                          1 <= a:0 ? a:1 : expand('%:p:h'),
   \                          2 <= a:0 ? a:2 : -1)
-    " XXX: Handle error?
-    source `=file`
+    try
+      execute 'source' fnameescape(file)
+    catch /^Vim\%((\a\+)\)\=:E/
+      " v:exception contains what is normally in v:errmsg, but with extra
+      " exception source info prepended, which we cut away.
+      let v:errmsg = substitute(v:exception, '^Vim\%((\a\+)\)\=:', '', '')
+      echohl ErrorMsg
+      echomsg printf('Error detected while processing %s:', file)
+      echomsg v:errmsg
+      echohl None
+    endtry
   endfor
 endfunction
 

--- a/doc/localrc.txt
+++ b/doc/localrc.txt
@@ -43,7 +43,14 @@ The configuration file is loaded at the timing of |BufReadPost| and
 Vim with no file.
 
 Configuration file applied only to a specific filetype can be put.  The file
-name is specified by |g:localrc_filetype|.
+name is specified by |g:localrc_filetype|.  Filetype-specific configuration is
+always executed _after_ the global configuration, so you can override global
+stuff in there.  (The filetype may have already been set during execution of
+the global configuration, but not when set manually or from a modeline, so
+it's advisable to use the specific configuration files instead of handling all
+filetypes in the global one.)  For a compound filetype like "foo.bar",
+configuration for "foo", "bar", and "foo.bar" is searched.
+
 
 When two or more configuration files exist, it is sequentially loaded from a
 shallow hierarchy.

--- a/doc/localrc.txt
+++ b/doc/localrc.txt
@@ -39,17 +39,25 @@ The configuration file is a Vim script of a decided file name like ".vimrc".
 The file name is specified by |g:localrc_filename|.
 
 The configuration file is loaded at the timing of |BufReadPost| and
-|BufNewFile|.  And, it is loaded also at the timing of |VimEnter| if you start
-Vim with no file.
+|BufNewFile|, but before any |ftplugins|.  And, it is loaded also at the
+timing of |VimEnter| if you start Vim with no file.
 
-Configuration file applied only to a specific filetype can be put.  The file
-name is specified by |g:localrc_filetype|.  Filetype-specific configuration is
-always executed _after_ the global configuration, so you can override global
-stuff in there.  (The filetype may have already been set during execution of
+Configuration can also be applied to a (set of) specific filetype(s).
+The file name is specified by |g:localrc_filetype|.  This depends on
+|:filetype-plugin-on|.
+Filetype-specific configuration is always executed _after_ the global
+configuration and _after_ ftplugins, so you can override global and filetype
+settings in there.  The filetype may have already been set during execution of
 the global configuration, but not when set manually or from a modeline, so
 it's advisable to use the specific configuration files instead of handling all
-filetypes in the global one.)  For a compound filetype like "foo.bar",
-configuration for "foo", "bar", and "foo.bar" is searched.
+filetypes in the global one, also to ensure the correct execution order:
+    vimrc -> global configuration -> ftplugins -> filetype-specific config
+
+For a compound filetype like "foo.bar", configuration for "foo", "bar", and
+"foo.bar" is searched.  (Please note that the default, dot-separated
+|g:localrc_filetype| pattern is not particularly well suited for exact matches
+of compound filetypes; you may want to switch to another delimiter if you have
+such advanced needs.)
 
 
 When two or more configuration files exist, it is sequentially loaded from a

--- a/plugin/localrc.vim
+++ b/plugin/localrc.vim
@@ -34,12 +34,6 @@ augroup plugin-localrc
   autocmd BufReadPre * unlet! b:localrc_done " Clear to support reload via :edit!.
   autocmd BufNewFile,BufReadPost * nested
   \   if !exists('b:localrc_done') | call localrc#load(g:localrc_filename) | let b:localrc_done = 1 | endif
-  autocmd FileType * nested
-  \   if !exists('b:localrc_done') | call localrc#load(g:localrc_filename) | let b:localrc_done = 1 | endif |
-  \   call localrc#loadft(
-  \     type(g:localrc_filetype) == type([]) ? copy(g:localrc_filetype)
-  \                                          : [g:localrc_filetype],
-  \     expand("<amatch>"))
 augroup END
 
 

--- a/plugin/localrc.vim
+++ b/plugin/localrc.vim
@@ -31,9 +31,10 @@ augroup plugin-localrc
   " set manually or via modeline). Use a flag to ensure that global localrc is
   " always executed before the filetype-specific ones, so that they can override
   " global localrc settings.
-  autocmd BufReadPre * unlet! b:localrc_done " Clear to support reload via :edit!.
-  autocmd BufNewFile,BufReadPost * nested
-  \   if !exists('b:localrc_done') | call localrc#load(g:localrc_filename) | let b:localrc_done = 1 | endif
+  " Local settings may be set dynamically based on the filename. Therefore, also
+  " hook into file renamings via :file and :saveas.
+  autocmd BufReadPre,BufFilePre * unlet! b:localrc_done " Clear to support reload via :edit! / file renamings via :file and :saveas.
+  autocmd BufNewFile,BufReadPost,BufFilePost * nested if !exists('b:localrc_done') | call localrc#load(g:localrc_filename) | let b:localrc_done = 1 | endif
 augroup END
 
 

--- a/plugin/localrc.vim
+++ b/plugin/localrc.vim
@@ -26,9 +26,16 @@ augroup plugin-localrc
   \                  if argc() == 0
   \                |   call localrc#load(g:localrc_filename)
   \                | endif
+  " Depending on the circumstances, the FileType autocmd may execute before
+  " BufReadPost (automatic filetype detection) or after BufReadPost (filetype
+  " set manually or via modeline). Use a flag to ensure that global localrc is
+  " always executed before the filetype-specific ones, so that they can override
+  " global localrc settings.
+  autocmd BufReadPre * unlet! b:localrc_done " Clear to support reload via :edit!.
   autocmd BufNewFile,BufReadPost * nested
-  \   call localrc#load(g:localrc_filename)
+  \   if !exists('b:localrc_done') | call localrc#load(g:localrc_filename) | let b:localrc_done = 1 | endif
   autocmd FileType * nested
+  \   if !exists('b:localrc_done') | call localrc#load(g:localrc_filename) | let b:localrc_done = 1 | endif |
   \   call localrc#load(
   \     map(type(g:localrc_filetype) == type([]) ? copy(g:localrc_filetype)
   \                                              : [g:localrc_filetype],

--- a/plugin/localrc.vim
+++ b/plugin/localrc.vim
@@ -36,10 +36,10 @@ augroup plugin-localrc
   \   if !exists('b:localrc_done') | call localrc#load(g:localrc_filename) | let b:localrc_done = 1 | endif
   autocmd FileType * nested
   \   if !exists('b:localrc_done') | call localrc#load(g:localrc_filename) | let b:localrc_done = 1 | endif |
-  \   call localrc#load(
-  \     map(type(g:localrc_filetype) == type([]) ? copy(g:localrc_filetype)
-  \                                              : [g:localrc_filetype],
-  \         'printf(v:val, expand("<amatch>"))'))
+  \   call localrc#loadft(
+  \     type(g:localrc_filetype) == type([]) ? copy(g:localrc_filetype)
+  \                                          : [g:localrc_filetype],
+  \     expand("<amatch>"))
 augroup END
 
 

--- a/plugin/localrc.vim
+++ b/plugin/localrc.vim
@@ -3,7 +3,7 @@
 " Author : thinca <thinca+vim@gmail.com>
 " License: zlib License
 
-if exists('g:loaded_localrc')
+if exists('g:loaded_localrc') || v:version < 700
   finish
 endif
 let g:loaded_localrc = 1


### PR DESCRIPTION
Hello thinca-san,

I have been using your excellent plugin for quite some time, as I found it to be the best among various "local configuration" plugins, especially because it allows both global and filetype-specific configuration.

Using the latter, though, I found some inconsistencies, especially in the order of sourcing, that were frustrating my attempts to define global configuration in a .local.vimrc and then override some of that in a filetype-specific localrc.

I have extended the plugin logic to deal with this in the correct order (which is somewhat complex, necessitating a hook into Vim's ftplugin.vim script), but now it works satisfactorily for all my advanced uses.

Please have a look at my changes, maybe try them out yourself, and feel free to incorporate some or all of them into your official plugin version, so that other users can benefit from my extensions, too.
