### PR TITLE
Fix not loaded localrc when opened file by other script

### DIFF
--- a/plugin/localrc.vim
+++ b/plugin/localrc.vim
@@ -24,7 +24,7 @@ augroup plugin-localrc
   autocmd!
   autocmd VimEnter * nested
   \                  if argc() == 0
-  \                |   call localrc#load(g:localrc_filename)
+  \                |   call localrc#load(g:localrc_filename, getcwd())
   \                | endif
   autocmd BufNewFile,BufReadPost * nested
   \   call localrc#load(g:localrc_filename)


### PR DESCRIPTION
- Problem: Loading opened file side localrc when executing vim without filename arguments and opened file by script

- Solution: Changed file path search at VimEnter timing to use getcwd
