### PR TITLE
globpath('/', '/*') makes hang on msys2/cygwin.

### DIFF
--- a/autoload/localrc.vim
+++ b/autoload/localrc.vim
@@ -49,8 +49,8 @@ function! s:match_files(path, fname)
 
   let path = escape(a:path, '*?[,')
   if a:fname[0] == '/'
-    let files = split(globpath(path, '/.*', 1), "\n")
-    \         + split(globpath(path, '/*' , 1), "\n")
+    let files = split(globpath(path, '.*', 1), "\n")
+    \         + split(globpath(path, '*' , 1), "\n")
     let pat = a:fname[1:]
     call filter(map(files, 'fnamemodify(v:val, ":t")'), 'v:val =~# pat')
 


### PR DESCRIPTION
Probably, `ls //*` looks UNC paths.

Fixes #6